### PR TITLE
Add support for robots.txt & ads.txt

### DIFF
--- a/now.json
+++ b/now.json
@@ -16,6 +16,10 @@
       "src": "/wp-json/(.*)",
       "status": 301,
       "headers": { "Location": "https://wp.stanforddaily.com/wp-json/$1" }
+    },
+    {
+      "src": "/robots.txt",
+      "dest": "https://wp.stanforddaily.com/robots.txt"
     }
   ]
 }

--- a/now.json
+++ b/now.json
@@ -20,6 +20,10 @@
     {
       "src": "/robots.txt",
       "dest": "https://wp.stanforddaily.com/robots.txt"
+    },
+    {
+      "src": "/ads.txt",
+      "dest": "https://wp.stanforddaily.com/ads.txt"
     }
   ]
 }


### PR DESCRIPTION
Fix #31.

We proxy `/robots.txt` to `https://wp.stanforddaily.com/robots.txt` and `/ads.txt` to `https://wp.stanforddaily.com/ads.txt`.