### PR TITLE
Fix font size

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -289,9 +289,11 @@ export default class MyApp extends App {
         {/* `body` `overflow: initial` is added in order for `position: "sticky"` below to work. */}
         <Global
           styles={css`
+            html {
+              font-size: 0.8em;
+            }
             body {
               overflow: initial;
-              font-size: 0.8em;
             }
             .visible-mobile {
               @media (min-width: ${BREAKPOINTS.TABLET}px) {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -291,6 +291,7 @@ export default class MyApp extends App {
           styles={css`
             body {
               overflow: initial;
+              font-size: 0.8em;
             }
             .visible-mobile {
               @media (min-width: ${BREAKPOINTS.TABLET}px) {


### PR DESCRIPTION
The font size must have gotten bigger in the expo upgrade (#81). This PR fixes it:

Before: (http://localhost:3000/2020/04/16/next-academic-year-could-start-in-winter-provost-says/)

![image](https://user-images.githubusercontent.com/1689183/79791952-21f13400-831c-11ea-83c7-e2ac5e553177.png)

After:

![image](https://user-images.githubusercontent.com/1689183/79792050-46e5a700-831c-11ea-9029-0e403aad1e04.png)
