### PR TITLE
Fix search page issues

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,4 +11,5 @@ myNextApplication:
         forward:
           headers: 'none'
           cookies: 'none'
-          queryString: false
+          queryString: true
+          queryStringCacheKeys: ['s']


### PR DESCRIPTION
The problem with search was that after I turned on caching for the website yesterday, the way the cloudfront cache was configured was that it would ignore query strings. This means that https://www.stanforddaily.com/?s=search%20query and https://www.stanforddaily.com/ would both resolve to https://www.stanforddaily.com/ -- and that's why we were seeing the home page after searching.

This PR changes the cloudfront configuration to forward query strings and cache results only based on the `s` query string parameter -- this way, searches will work.

I've already deployed this and search works now, but made it in a PR so we can make sure this approach is the best.