### PR TITLE
Added Satire section on homepage, without category tag, linked with n…

### DIFF
--- a/components/ArticlesView.tsx
+++ b/components/ArticlesView.tsx
@@ -54,6 +54,7 @@ interface ArticlesViewProps {
   displayLoadMore?: boolean;
   displayExcerpt?: boolean;
   displayDateAuthor?: boolean;
+  hideCategory?: boolean;
   textColor?: string;
 
   // Whether the first article is enlarged / "featured". Currently
@@ -68,6 +69,7 @@ const ArticlesView: React.ElementType<ArticlesViewProps> = ({
   displayLoadMore = true,
   displayExcerpt = true,
   displayDateAuthor = true,
+  hideCategory = false,
   textColor = STANFORD_COLORS.BLACK,
   enlargeFirstArticle = false,
 }: ArticlesViewProps) => {
@@ -105,7 +107,7 @@ const ArticlesView: React.ElementType<ArticlesViewProps> = ({
           ) : (
             <TextOnlyArticle
               post={post}
-              displayCategory={displayCategory}
+              displayCategory={hideCategory ? false : displayCategory}
               displayExcerpt={displayExcerpt}
               displayDateAuthor={displayDateAuthor}
               textColor={textColor}

--- a/components/pages/ArticlePage/index.tsx
+++ b/components/pages/ArticlePage/index.tsx
@@ -5,6 +5,7 @@ import { getPostAsync, getPostPath, Post } from "helpers/wpapi";
 import { STRINGS } from "helpers/constants";
 import LoadingView from "components/Loading";
 import ContentView from "components/ContentView";
+import DonationForm from "components/DonationForm";
 
 interface ArticlePageProps {
   post?: Post;

--- a/components/pages/HomePage/SatireSection.tsx
+++ b/components/pages/HomePage/SatireSection.tsx
@@ -17,7 +17,7 @@ export const SatireSection: React.ElementType<SectionProps> = ({
       }}
     >
       <SectionTitleColorBackground>Satire</SectionTitleColorBackground>
-      <br></br>
+      <br />
       <ArticlesView
         initPosts={content}
         displayLoadMore={false}

--- a/components/pages/HomePage/SatireSection.tsx
+++ b/components/pages/HomePage/SatireSection.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Section } from "components/Section";
+import ArticlesView from "components/ArticlesView";
+import { STANFORD_COLORS } from "helpers/constants";
+import { SectionProps } from "./SectionProps";
+import { SectionTitle, SectionTitleColorBackground } from "./SectionTitle";
+
+export const SatireSection: React.ElementType<SectionProps> = ({
+  content,
+}: SectionProps) => {
+  return (
+    <Section
+      style={{
+        backgroundColor: STANFORD_COLORS.CARDINAL_RED,
+        flexGrow: 1,
+        flexDirection: "column",
+      }}
+    >
+      <SectionTitleColorBackground>Satire</SectionTitleColorBackground>
+      <br></br>
+      <ArticlesView
+        initPosts={content}
+        displayLoadMore={false}
+        displayExcerpt={false}
+        displayDateAuthor={false}
+        hideCategory={true}
+        textColor={STANFORD_COLORS.WHITE}
+      />
+    </Section>
+  );
+};

--- a/components/pages/HomePage/SectionTitle.tsx
+++ b/components/pages/HomePage/SectionTitle.tsx
@@ -12,10 +12,24 @@ const SectionTitleStyle = styled.Text({
   margin: 0,
   textTransform: "none",
 });
+
+const SectionTitleStyleColorBackground = styled.Text({
+  ...FONTS.SECTION_TITLE,
+  color: STANFORD_COLORS.WHITE,
+  fontSize: 20,
+  margin: 0,
+  textTransform: "none",
+});
+
 const SectionTitleElement =
   Platform.OS === "web"
     ? SectionTitleStyle.withComponent("h1")
     : SectionTitleStyle;
+
+const SectionTitleElementColorBackground =
+  Platform.OS === "web"
+    ? SectionTitleStyleColorBackground.withComponent("h1")
+    : SectionTitleStyleColorBackground;
 
 type SectionTitleProps = {
   category?: Category;
@@ -29,6 +43,16 @@ export const SectionTitle: React.ElementType<SectionTitleProps> = ({
   children = category.name,
 }: SectionTitleProps) => {
   return <SectionTitleElement style={style}>{children}</SectionTitleElement>;
+};
+
+export const SectionTitleColorBackground: React.ElementType<
+  SectionTitleProps
+> = ({ category, style, children = category.name }: SectionTitleProps) => {
+  return (
+    <SectionTitleElementColorBackground style={style}>
+      {children}
+    </SectionTitleElementColorBackground>
+  );
 };
 
 type SectionTitleWithLinkProps = SectionTitleProps & {

--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -10,7 +10,7 @@ import {
   isWidthGreaterThanOrEqualTo,
 } from "emotion-native-media-query";
 import { BREAKPOINTS } from "helpers/constants";
-import { getHomeAsync, Home } from "helpers/wpapi";
+import { getHomeAsync, Home, getCategoryAsync } from "helpers/wpapi";
 import Wrapper from "components/Wrapper";
 import { CategoryList } from "components/CategoryList";
 import LoadingView from "components/Loading";
@@ -24,6 +24,7 @@ import { GrindSection } from "./GrindSection";
 import { OpinionSection } from "./OpinionSection";
 import { ArtsAndLifeSection } from "./ArtsAndLifeSection";
 import { CartoonsSection } from "./CartoonsSection";
+import { SatireSection } from "./SatireSection";
 import { SponsoredSection } from "./SponsoredSection";
 import { MultimediaSection } from "./MultimediaSection";
 import { MoreFromTheDailySection } from "./MoreFromTheDailySection";
@@ -33,6 +34,7 @@ import { getBorderValue } from "./getBorderValue";
 
 interface IndexProps {
   homePosts?: Home;
+  Post;
   navigation?: any;
   refreshControl?: any;
 }
@@ -206,7 +208,10 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
                 ...getBorderValue("Bottom"),
               }}
             /> */}
-            {/* <SponsoredSection category={null} content={homePosts.sponsored} /> */}
+            <SatireSection
+              category={homePosts.tsdMeta.categories.satire}
+              content={homePosts.satire}
+            />
             <MoreFromTheDailySection
               category={null}
               content={homePosts.moreFromTheDaily}

--- a/helpers/wpapi.ts
+++ b/helpers/wpapi.ts
@@ -20,6 +20,7 @@ export type Home = Base & {
   theGrind: Post[];
   artsAndLife: Post[];
   cartoons: Post[];
+  satire: Post[];
   sponsored: Post[];
   moreFromTheDaily: Post[];
   tsdMeta: {
@@ -29,6 +30,7 @@ export type Home = Base & {
       sports: Category;
       opinions: Category;
       "arts-life": Category;
+      satire: Category;
       thegrind: Category;
       cartoons: Category;
     };


### PR DESCRIPTION
Adds satire section to homepage, above "more from the Daily"
<img width="1375" alt="Screen Shot 2020-05-03 at 11 38 39 am" src="https://user-images.githubusercontent.com/35205094/80921349-17c73080-8d33-11ea-86df-575a38088871.png">
