### PR TITLE
Rename build action from "Deploy" to "Build"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Otherwise, the checks on PRs are kind of misleading -- it's called "Deploy" even though the check only does a "Build".

![image](https://user-images.githubusercontent.com/1689183/81073362-8633fc00-8eb5-11ea-8a81-4e2e2318ec64.png)
