### PR TITLE
Add p to queryStringCacheKeys

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -12,4 +12,4 @@ myNextApplication:
           headers: 'none'
           cookies: 'none'
           queryString: true
-          queryStringCacheKeys: ['s']
+          queryStringCacheKeys: ['s', 'p']


### PR DESCRIPTION
This fixes an issue where a page like https://www.stanforddaily.com/?p=1168395 would always redirect to the front page (this is what is linked to by the "Also on the Stanford Daily" section at the bottom of each article).

In fact, this issue was probably what caused the weird problem earlier of the home page redirecting to a random article. Basically, when the cache expired (the cache expires every 60 seconds), someone clicked right at https://www.stanforddaily.com/?p=1168395, so this meant that for the next minute, all queries to https://www.stanforddaily.com/ would actually show the article shown at https://www.stanforddaily.com/?p=1168395.