### PR TITLE
Remove extra /> at end of articles

### DIFF
--- a/components/ContentView.tsx
+++ b/components/ContentView.tsx
@@ -218,7 +218,6 @@ const ContentView: React.ElementType<ContentViewProps> = ({
           `,
               }}
             />
-            />
           </div>
         </React.Fragment>
       )}


### PR DESCRIPTION

## Reasons for making this change

This was accidentally added in https://github.com/TheStanfordDaily/stanforddaily/commit/8caaa9f4f36a23113b08ee94cd13ca3d1117ecd3

fixes #123
