### PR TITLE
Fix to replace "Untitled" on the home page

### DIFF
--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -99,7 +99,6 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
     return (
       <>
         <Head>
-          <title>Homepage | The Stanford Daily</title>
           <meta
             name="viewport"
             content="initial-scale=1.0, width=device-width"
@@ -250,7 +249,7 @@ export function HomePageWrapper(props): any {
   );
 }
 HomePageWrapper.navigationOptions = {
-  title: "The Stanford Daily",
+  title: "Thea Stanford Daily",
   headerBackTitle: "Home",
   headerTitleStyle: {
     fontFamily: "Canterbury",

--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -249,7 +249,7 @@ export function HomePageWrapper(props): any {
   );
 }
 HomePageWrapper.navigationOptions = {
-  title: "Thea Stanford Daily",
+  title: "The Stanford Daily",
   headerBackTitle: "Home",
   headerTitleStyle: {
     fontFamily: "Canterbury",

--- a/components/webHelpers/WPHead.web.tsx
+++ b/components/webHelpers/WPHead.web.tsx
@@ -10,7 +10,7 @@ const WPHead: React.ElementType<BaseProps> = ({ base }) => {
       <Head>
         {ReactHtmlParser(
           base.tsdMeta.wpHead.replace(
-            "Untitled | The Stanford Daily",
+            /Untitled \| The Stanford Daily/g,
             "Homepage | The Stanford Daily",
           ),
         )}

--- a/components/webHelpers/WPHead.web.tsx
+++ b/components/webHelpers/WPHead.web.tsx
@@ -5,7 +5,17 @@ import { BaseProps } from "./baseTypes";
 
 const WPHead: React.ElementType<BaseProps> = ({ base }) => {
   if (base && base.tsdMeta && base.tsdMeta.wpHead) {
-    return <Head>{ReactHtmlParser(base.tsdMeta.wpHead)}</Head>;
+    // Fix to replace "Untitled" on the home page
+    return (
+      <Head>
+        {ReactHtmlParser(
+          base.tsdMeta.wpHead.replace(
+            "Untitled | The Stanford Daily",
+            "Homepage | The Stanford Daily",
+          ),
+        )}
+      </Head>
+    );
   } else {
     return <></>;
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/TheStanfordDaily/stanford-daily.git"
+    "url": "https://github.com/TheStanfordDaily/stanforddaily.git"
   },
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {


### PR DESCRIPTION
## Reasons for making this change

Home page says "Untitled | The Stanford Daily" as the page title on the web browser

Now, it will say "Homepage | The Stanford Daily"