### PR TITLE
Don't redirect errors to /wp-json/

### DIFF
--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,3 +1,0 @@
-import Redirect from "./_redirect";
-
-export default Redirect;

--- a/pages/wp-json/[...slug].tsx
+++ b/pages/wp-json/[...slug].tsx
@@ -1,0 +1,9 @@
+import Redirect from "../_redirect";
+
+/**
+ * This page is called [...slug].tsx, which allows it to match arbitrarily nested paths.
+ * This means that all paths under https://stanforddaily.com/wp-json/... will be redirected
+ * to their corresponding https://wp.stanforddaily.com/wp-json/... paths.
+ */
+
+export default Redirect;

--- a/pages/wp-json/index.tsx
+++ b/pages/wp-json/index.tsx
@@ -1,3 +1,0 @@
-import Redirect from "../_redirect";
-
-export default Redirect;


### PR DESCRIPTION
## Reasons for making this change

Previously, we had redirected all errors on the stanford daily page to https://wp.stanforddaily.com/wp-json/. This is because in order for the REST API to work, we need to redirect all paths from https://stanforddaily.com/wp-json/... to their corresponding https://wp.stanforddaily.com/wp-json/... paths.

However, this caused issues because when there was just an error on the page with rendering an article (which has nothing to do with the REST API), it would also redirect to /wp-json/ and become cached, so users would commonly just see code when going to our site.

This PR changes that approach by:
- Using the default error page, so users will just see a "404 not found" or some error like that instead of being redirected to code.
- Using the `[...slug].tsx` feature of Next.js, which allows us to redirect an arbitrarily-long path after https://stanforddaily.com/wp-json/... to https://wp.stanforddaily.com/wp-json/... . (see this page for more information: https://nextjs.org/docs/routing/dynamic-routes#catch-all-routes)

## Testing

http://localhost:3000/wp-json/tsd/json/v1/tag/coronavirus/1 should redirect to https://wp.stanforddaily.com/wp-json/tsd/json/v1/tag/coronavirus/1.