### PR TITLE
Vertically aligned large numbers in COVID-19 data widget; relocated on mobile

### DIFF
--- a/components/pages/HomePage/CovidDataWidget.tsx
+++ b/components/pages/HomePage/CovidDataWidget.tsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useState } from "react";
+
+//Replace these two with your own!
+const SHEET_ID = "1darMs2BhXBjSRcuQYi33dKzIAgUSenZjYF9ZrRjqNiY";
+const ACCESS_TOKEN = "AIzaSyAh_wwePZswl21zxnjGaiBM0Q-yQ8miOgE";
+
+export const CovidDataWidget: React.ElementType = () => {
+  const [stats, setStats] = useState(null);
+
+  // async function getSheetValues() {
+  //     const request = await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/B22:B23?key=${ACCESS_TOKEN}`,
+  //     {
+  //     headers: {
+  //         "Content-Type": "application/json",
+  //     }
+  //     });
+  //     const data = await request.json();
+  //     console.log(data);
+  //     console.log(data.values[0][0]);
+  //     setStats(data);
+  // }
+
+  // useEffect(() => {
+  //     // Update the document title using the browser API
+  //     getSheetValues(); // await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/B22:B23?key=${ACCESS_TOKEN}`,
+  //     // {
+  //     //   headers: {
+  //     //     "Content-Type": "application/json",
+  //     // }
+  //     // });
+
+  // }, []);
+
+  return (
+    <section className="css-cliv5m" style={{ padding: "15px" }}>
+      <div className="css-6jlpjt">
+        <div
+          dir="auto"
+          className="css-901oao"
+          style={{
+            fontFamily: "IBM Plex Sans Condensed, sans-serif",
+            lineHeight: "1em",
+            textTransform: "uppercase",
+          }}
+        >
+          <a
+            title="Opinions"
+            style={{ color: "inherit" }}
+            href="/category/opinions/"
+          >
+            <h1
+              style={{
+                fontFamily: "Open Sans, sans-serif",
+                fontWeight: 900,
+                fontSize: "20px",
+                lineHeight: "normal",
+                color: "#820000",
+                margin: 0,
+                textTransform: "none",
+              }}
+            >
+              COVID-19
+            </h1>
+          </a>
+        </div>
+        <div
+          className=" tracking-boxes"
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            marginTop: "10px",
+            justifyContent: "space-between",
+          }}
+        >
+          <div
+            className=" tracking-box"
+            style={{
+              width: "30%",
+              height: "16.5vh",
+              backgroundColor: "#fef2f1",
+              textAlign: "center",
+              paddingTop: "2%",
+            }}
+          >
+            <div
+              style={{
+                fontSize: "1.75vh",
+                lineHeight: "normal",
+                paddingBottom: "1vh",
+              }}
+            >
+              Undergrad and grad student positives
+            </div>
+            <div>
+              <strong style={{ fontSize: "3vh" }}>
+                33<strong></strong>
+              </strong>
+            </div>
+            <div style={{ fontSize: "1.75vh", lineHeight: "normal" }}>
+              <span>
+                Last week
+                <br />
+                +1
+              </span>{" "}
+              <span style={{ color: "#585858" }}>▼</span>
+            </div>
+          </div>
+          <div
+            className=" tracking-box"
+            style={{
+              width: "30%",
+              height: "16.5vh",
+              backgroundColor: "#fef2f1",
+              textAlign: "center",
+              paddingTop: "2%",
+            }}
+          >
+            <div
+              style={{
+                fontSize: "1.75vh",
+                lineHeight: "normal",
+                paddingBottom: "1vh",
+              }}
+            >
+              Faculty, staff and postdocs positives
+            </div>
+            <div>
+              <strong style={{ fontSize: "3vh" }}>
+                6<strong></strong>
+              </strong>
+            </div>
+            <div style={{ fontSize: "1.75vh", lineHeight: "normal" }}>
+              <span>
+                Last week
+                <br />
+                +0
+              </span>{" "}
+              <span style={{ color: "#585858" }}>▼</span>
+            </div>
+          </div>
+          <div
+            className=" tracking-box"
+            style={{
+              width: "30%",
+              height: "16.5vh",
+              backgroundColor: "#fef2f1",
+              textAlign: "center",
+              paddingTop: "2%",
+            }}
+          >
+            <div
+              style={{
+                fontSize: "1.75vh",
+                lineHeight: "normal",
+                paddingBottom: "1vh",
+              }}
+            >
+              Total tests administered
+            </div>
+            <div>
+              <strong style={{ fontSize: "3vh" }}>33,479</strong>
+            </div>
+            <div style={{ fontSize: "1.75vh", lineHeight: "normal" }}>
+              <span>
+                Last week
+                <br />
+                +6,278
+              </span>{" "}
+              <span style={{ color: "#585858" }}>▲</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={{
+          textAlign: "center",
+          marginTop: "5px",
+          marginBottom: "5px",
+          fontFamily: "Libre Baskerville, sans-serif",
+          fontSize: "10px",
+          lineHeight: "normal",
+        }}
+      >
+        Results are from Stanford's surveillance testing program. Arrows
+        indicate whether last week's counts trended up or down from the previous
+        week.
+      </div>
+      <div style={{ textAlign: "center" }}>
+        {" "}
+        <h2
+          style={{
+            fontFamily: "Libre Baskerville, sans-serif",
+            fontWeight: "bold",
+            fontSize: "15px",
+            lineHeight: "normal",
+            margin: 0,
+            marginTop: "5px",
+            marginBottom: "5px",
+            textAlign: "center",
+          }}
+        >
+          {" "}
+          <a
+            title=" Letter to the community: Welcoming VP Chris Middleton to the ASSU exec team"
+            style={{ color: "inherit" }}
+            href="stanforddaily.com"
+          >
+            Tracking COVID-19 at Stanford
+          </a>
+        </h2>
+      </div>
+    </section>
+  );
+};

--- a/components/pages/HomePage/CovidDataWidget.tsx
+++ b/components/pages/HomePage/CovidDataWidget.tsx
@@ -201,9 +201,9 @@ export const CovidDataWidget: React.ElementType = () => {
         >
           {" "}
           <a
-            title=" Letter to the community: Welcoming VP Chris Middleton to the ASSU exec team"
+            title="Tracking COVID-19 at Stanford"
             style={{ color: "inherit" }}
-            href="stanforddaily.com"
+            href="https://www.stanforddaily.com/2020/10/11/tracking-covid-19-at-stanford/"
           >
             Tracking COVID-19 at Stanford
           </a>

--- a/components/pages/HomePage/CovidDataWidget.tsx
+++ b/components/pages/HomePage/CovidDataWidget.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from "react";
+import { BREAKPOINTS } from "helpers/constants";
+import css from "@emotion/css";
 
 //Replace these two with your own!
 const SHEET_ID = "1darMs2BhXBjSRcuQYi33dKzIAgUSenZjYF9ZrRjqNiY";
 const ACCESS_TOKEN = "AIzaSyAh_wwePZswl21zxnjGaiBM0Q-yQ8miOgE";
 
-export const CovidDataWidget: React.ElementType = () => {
+export const CovidDataWidget: React.ElementType = ({ mobile = false }) => {
   const [stats, setStats] = useState(null);
 
   // async function getSheetValues() {
@@ -32,7 +34,23 @@ export const CovidDataWidget: React.ElementType = () => {
   // }, []);
 
   return (
-    <section className="css-cliv5m" style={{ padding: "15px" }}>
+    <section
+      className="css-cliv5m"
+      style={{ padding: "15px" }}
+      css={
+        mobile
+          ? css`
+              @media (min-width: ${BREAKPOINTS.TABLET}px) {
+                display: none;
+              }
+            `
+          : css`
+              @media (max-width: ${BREAKPOINTS.MAX_WIDTH.TABLET}px) {
+                display: none;
+              }
+            `
+      }
+    >
       <div className="css-6jlpjt">
         <div
           dir="auto"
@@ -76,7 +94,7 @@ export const CovidDataWidget: React.ElementType = () => {
             className=" tracking-box"
             style={{
               width: "30%",
-              height: "16.5vh",
+              height: "17vh",
               backgroundColor: "#fef2f1",
               textAlign: "center",
               paddingTop: "2%",
@@ -87,6 +105,9 @@ export const CovidDataWidget: React.ElementType = () => {
                 fontSize: "1.75vh",
                 lineHeight: "normal",
                 paddingBottom: "1vh",
+                height: "45%",
+                display: "flex",
+                alignItems: "center",
               }}
             >
               Undergrad and grad student positives
@@ -109,7 +130,7 @@ export const CovidDataWidget: React.ElementType = () => {
             className=" tracking-box"
             style={{
               width: "30%",
-              height: "16.5vh",
+              height: "17vh",
               backgroundColor: "#fef2f1",
               textAlign: "center",
               paddingTop: "2%",
@@ -117,6 +138,9 @@ export const CovidDataWidget: React.ElementType = () => {
           >
             <div
               style={{
+                height: "45%",
+                display: "flex",
+                alignItems: "center",
                 fontSize: "1.75vh",
                 lineHeight: "normal",
                 paddingBottom: "1vh",
@@ -142,7 +166,7 @@ export const CovidDataWidget: React.ElementType = () => {
             className=" tracking-box"
             style={{
               width: "30%",
-              height: "16.5vh",
+              height: "17vh",
               backgroundColor: "#fef2f1",
               textAlign: "center",
               paddingTop: "2%",
@@ -153,6 +177,9 @@ export const CovidDataWidget: React.ElementType = () => {
                 fontSize: "1.75vh",
                 lineHeight: "normal",
                 paddingBottom: "1vh",
+                height: "45%",
+                display: "flex",
+                alignItems: "center",
               }}
             >
               Total tests administered

--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -29,7 +29,7 @@ import { MoreFromTheDailySection } from "./MoreFromTheDailySection";
 import { DesktopRow } from "./DesktopRow";
 import { Column } from "./Column";
 import { getBorderValue } from "./getBorderValue";
-import { CovidDataWidget } from "components/pages/HomePage/CovidDataWidget.tsx";
+import { CovidDataWidget } from "components/pages/HomePage/CovidDataWidget";
 
 interface IndexProps {
   homePosts?: Home;
@@ -141,6 +141,7 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
                     </>
                   )}
                 </DesktopRow>
+                <CovidDataWidget mobile={true} />
                 <SportsSection
                   content={homePosts.sports}
                   category={homePosts.tsdMeta.categories.sports}

--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -29,6 +29,7 @@ import { MoreFromTheDailySection } from "./MoreFromTheDailySection";
 import { DesktopRow } from "./DesktopRow";
 import { Column } from "./Column";
 import { getBorderValue } from "./getBorderValue";
+import { CovidDataWidget } from "components/pages/HomePage/CovidDataWidget.tsx";
 
 interface IndexProps {
   homePosts?: Home;
@@ -165,6 +166,7 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
                   },
                 }}
               >
+                <CovidDataWidget />
                 <OpinionSection
                   content={homePosts.opinions}
                   category={homePosts.tsdMeta.categories.opinions}


### PR DESCRIPTION
## Reasons for making this change

- Want widget to appear before Sports on mobile, and with numbers aligned vertically in all cases

## Related tickets

## Screenshots

[Desktop screenshot]

[Mobile screenshot]
