### PR TITLE
Homepage improvements: Remove dates; add custom logos; update COVID-19 tracker

### DIFF
--- a/components/ArticlesView.tsx
+++ b/components/ArticlesView.tsx
@@ -59,6 +59,9 @@ interface ArticlesViewProps {
   displayDateAuthor?: boolean;
   hideCategory?: boolean;
   textColor?: string;
+  noDates?: boolean;
+  isSatire?: boolean;
+  isSatire2?: boolean;
 
   // Tells whether the first article is enlarged / "featured" (true)
   // or not (false); currently enabled only on category pages
@@ -77,6 +80,9 @@ const ArticlesView: React.ElementType<ArticlesViewProps> = ({
   hideCategory = false,
   textColor = STANFORD_COLORS.BLACK,
   enlargeFirstArticle = false,
+  noDates,
+  isSatire = false,
+  isSatire2 = false,
 }: ArticlesViewProps) => {
   const [extraPosts, setExtraPosts]: [Post[], any] = React.useState([]);
   const [extraPageNumber, setExtraPageNumber]: [number, any] = React.useState(
@@ -118,6 +124,8 @@ const ArticlesView: React.ElementType<ArticlesViewProps> = ({
               displayExcerpt={displayExcerpt}
               displayDateAuthor={displayDateAuthor}
               textColor={textColor}
+              noDate={noDates}
+              isSatire2={isSatire2}
             />
           )}
         </EachArticleView>

--- a/components/AuthorAndDateView.tsx
+++ b/components/AuthorAndDateView.tsx
@@ -13,6 +13,7 @@ interface AuthorAndDateViewProps {
   dateFormat?: string;
   dateStyle?: TextStyle;
   newLineBetweenAuthorAndDate?: boolean;
+  noDate?: boolean;
 }
 
 // Author name(s) and date of publication for article shown on the
@@ -24,8 +25,9 @@ const AuthorAndDateView: React.ElementType<AuthorAndDateViewProps> = ({
   dateFormat,
   dateStyle,
   newLineBetweenAuthorAndDate = false,
+  noDate = false,
 }: AuthorAndDateViewProps) => {
-  if (newLineBetweenAuthorAndDate) {
+  if (!noDate && newLineBetweenAuthorAndDate) {
     // Format name(s)/date like this:
     // FIRSTNAME LASTNAME
     // JUL 25 2020
@@ -50,7 +52,7 @@ const AuthorAndDateView: React.ElementType<AuthorAndDateViewProps> = ({
         </>
       );
     }
-  } else {
+  } else if (!noDate) {
     // Format name(s)/date like this: FIRSTNAME LASTNAME • JUL 25 2020
     return (
       <Text
@@ -69,6 +71,20 @@ const AuthorAndDateView: React.ElementType<AuthorAndDateViewProps> = ({
           format={dateFormat}
           style={dateStyle}
           containerStyle={{ display: "inline-flex" }}
+        />
+      </Text>
+    );
+  } else {
+    return (
+      <Text
+        style={{
+          ...style,
+        }}
+      >
+        <AuthorView
+          authors={post.tsdAuthors}
+          containerStyle={{ display: "inline-flex" }}
+          style={authorStyle}
         />
       </Text>
     );

--- a/components/CategoryLink.tsx
+++ b/components/CategoryLink.tsx
@@ -11,6 +11,8 @@ interface CategoryLinkProps {
   category: Category;
   children?: ReactNode;
   style?: TextStyle;
+  isSatire?: Boolean;
+  isSatire2?: Boolean;
 
   // See "helpers/trivial/react-navigation"
   navigation?: any;
@@ -24,6 +26,8 @@ const _CategoryLink: React.ElementType<CategoryLinkProps> = ({
   children = (category && category.name) || "Uncategorized",
   style = {},
   navigation,
+  isSatire = false,
+  isSatire2 = false,
 }: CategoryLinkProps) => {
   if (Platform.OS !== "web") {
     return (
@@ -51,10 +55,20 @@ const _CategoryLink: React.ElementType<CategoryLinkProps> = ({
         ...style,
       }}
     >
-      {category ? (
-        <Link href={getNextJsCategoryPath(category.url)} as={category.url}>
-          <a title={category.name} style={{ color: "inherit" }}>
-            {children}
+      {category || isSatire || isSatire2 ? (
+        <Link
+          href={
+            isSatire || isSatire2
+              ? "/category/satire/"
+              : getNextJsCategoryPath(category.url)
+          }
+          as={isSatire || isSatire2 ? "/category/satire/" : category.url}
+        >
+          <a
+            title={isSatire || isSatire2 ? "Satire" : category.name}
+            style={{ color: "inherit" }}
+          >
+            {isSatire2 ? "Satire" : children}
           </a>
         </Link>
       ) : (

--- a/components/pages/HomePage/CartoonsSection.tsx
+++ b/components/pages/HomePage/CartoonsSection.tsx
@@ -21,7 +21,19 @@ export const CartoonsSection: React.ElementType = ({
   ) {
     return (
       <RView WebTag={Section} NativeTag={Section} {...props}>
-        <SectionTitleWithLink category={category} />
+        <SectionTitleWithLink category={category}>
+          <Image
+            source={{
+              uri: "/static/sectionHeaders/cartoons.png",
+            }}
+            accessibilityLabel="Cartoons"
+            resizeMode="contain"
+            style={{
+              width: 200,
+              height: 65,
+            }}
+          />
+        </SectionTitleWithLink>
         <LinkToArticle post={content[0]}>
           <Image
             source={{
@@ -31,7 +43,6 @@ export const CartoonsSection: React.ElementType = ({
             style={{
               width: "100%",
               height: 400,
-              marginTop: 20,
             }}
           />
         </LinkToArticle>

--- a/components/pages/HomePage/CovidDataWidget.tsx
+++ b/components/pages/HomePage/CovidDataWidget.tsx
@@ -80,6 +80,30 @@ export const CovidDataWidget: React.ElementType = ({ mobile = false }) => {
             </h1>
           </a>
         </div>
+        <div style={{ textAlign: "center" }}>
+          {" "}
+          <h2
+            style={{
+              fontFamily: "Libre Baskerville, sans-serif",
+              fontWeight: "bold",
+              fontSize: "15px",
+              lineHeight: "normal",
+              margin: 0,
+              marginTop: "5px",
+              marginBottom: "5px",
+              textAlign: "center",
+            }}
+          >
+            {" "}
+            <a
+              title="Tracking COVID-19 at Stanford"
+              style={{ color: "inherit" }}
+              href="https://www.stanforddaily.com/2020/10/11/tracking-covid-19-at-stanford/"
+            >
+              Tracking COVID-19 at Stanford
+            </a>
+          </h2>
+        </div>
         <div
           className=" tracking-boxes"
           style={{
@@ -113,16 +137,16 @@ export const CovidDataWidget: React.ElementType = ({ mobile = false }) => {
             </div>
             <div>
               <strong style={{ fontSize: "3vh" }}>
-                33<strong></strong>
+                42<strong></strong>
               </strong>
             </div>
             <div style={{ fontSize: "1.75vh", lineHeight: "normal" }}>
               <span>
                 Last week
                 <br />
-                +0
+                +9
               </span>{" "}
-              <span style={{ color: "#585858" }}>▼</span>
+              <span style={{ color: "#585858" }}>▲</span>
             </div>
           </div>
           <div
@@ -149,16 +173,16 @@ export const CovidDataWidget: React.ElementType = ({ mobile = false }) => {
             </div>
             <div>
               <strong style={{ fontSize: "3vh" }}>
-                7<strong></strong>
+                6<strong></strong>
               </strong>
             </div>
             <div style={{ fontSize: "1.75vh", lineHeight: "normal" }}>
               <span>
                 Last week
                 <br />
-                +1
+                +0
               </span>{" "}
-              <span style={{ color: "#585858" }}>▲</span>
+              <span style={{ color: "#585858" }}>▼</span>
             </div>
           </div>
           <div
@@ -207,33 +231,11 @@ export const CovidDataWidget: React.ElementType = ({ mobile = false }) => {
           lineHeight: "normal",
         }}
       >
-        Numbers indicate positive test results among each cohort. For cohorts excluding Stanford Health Care workers, results are from Stanford's surveillance testing and other Stanford-affiliated programs. Arrows
-        indicate whether last week's counts trended up or down from the previous
-        week.
-      </div>
-      <div style={{ textAlign: "center" }}>
-        {" "}
-        <h2
-          style={{
-            fontFamily: "Libre Baskerville, sans-serif",
-            fontWeight: "bold",
-            fontSize: "15px",
-            lineHeight: "normal",
-            margin: 0,
-            marginTop: "5px",
-            marginBottom: "5px",
-            textAlign: "center",
-          }}
-        >
-          {" "}
-          <a
-            title="Tracking COVID-19 at Stanford"
-            style={{ color: "inherit" }}
-            href="https://www.stanforddaily.com/2020/10/11/tracking-covid-19-at-stanford/"
-          >
-            Tracking COVID-19 at Stanford
-          </a>
-        </h2>
+        Numbers indicate positive test results among each cohort. For cohorts
+        excluding Stanford Health Care workers, results are from Stanford's
+        surveillance testing and other Stanford-affiliated programs. Arrow
+        indicates whether last week's increase was greater or less than that of
+        the prior week.
       </div>
     </section>
   );

--- a/components/pages/HomePage/HeadlineArticle.tsx
+++ b/components/pages/HomePage/HeadlineArticle.tsx
@@ -51,7 +51,7 @@ export const HeadlineArticle: React.ElementType = ({
       >
         <PostExcerpt post={post} />
       </View>
-      <AuthorAndDateView post={post} />
+      <AuthorAndDateView post={post} noDate />
     </Article>
   );
 };

--- a/components/pages/HomePage/ListStyleArticle.tsx
+++ b/components/pages/HomePage/ListStyleArticle.tsx
@@ -17,7 +17,9 @@ export const ListStyleArticle: React.ElementType = ({
       <ArticleHeader>
         <ArticleTitleWithLink post={post} marginBottomMore style={titleStyle} />
       </ArticleHeader>
-      {displayAuthor && <AuthorAndDateView post={post} style={authorStyle} />}
+      {displayAuthor && (
+        <AuthorAndDateView post={post} style={authorStyle} noDate />
+      )}
     </Article>
   );
 };

--- a/components/pages/HomePage/MoreFromTheDailySection.tsx
+++ b/components/pages/HomePage/MoreFromTheDailySection.tsx
@@ -21,6 +21,7 @@ export const MoreFromTheDailySection: React.ElementType<SectionProps> = ({
       <ArticlesView
         initPosts={content}
         displayExcerpt={false}
+        noDates={true}
         getExtraPosts={async pageNumber => {
           return getHomeMoreAsync(pageNumber);
         }}

--- a/components/pages/HomePage/SatireSection.tsx
+++ b/components/pages/HomePage/SatireSection.tsx
@@ -12,7 +12,7 @@ export const SatireSection: React.ElementType<SectionProps> = ({
   return (
     <Section
       style={{
-        backgroundColor: "#fcf2fb",
+        backgroundColor: "#fef2f1",
         flexGrow: 1,
         flexDirection: "column",
       }}

--- a/components/pages/HomePage/SatireSection.tsx
+++ b/components/pages/HomePage/SatireSection.tsx
@@ -1,30 +1,43 @@
 import React from "react";
+import { Image } from "react-native";
 import { Section } from "components/Section";
 import ArticlesView from "components/ArticlesView";
-import { STANFORD_COLORS } from "helpers/constants";
 import { SectionProps } from "./SectionProps";
-import { SectionTitleColorBackground } from "./SectionTitle";
+import { SectionTitleWithLink } from "./SectionTitle";
 
 export const SatireSection: React.ElementType<SectionProps> = ({
+  category,
   content,
 }: SectionProps) => {
   return (
     <Section
       style={{
-        backgroundColor: STANFORD_COLORS.CARDINAL_RED,
+        backgroundColor: "#fcf2fb",
         flexGrow: 1,
         flexDirection: "column",
       }}
     >
-      <SectionTitleColorBackground>Satire</SectionTitleColorBackground>
-      <br />
+      <SectionTitleWithLink category={category} isSatire={true}>
+        <Image
+          source={{
+            uri: "/static/soc-no-background.png",
+          }}
+          accessibilityLabel="Satire"
+          resizeMode="contain"
+          style={{
+            height: 75,
+            width: 300,
+            marginBottom: -20,
+          }}
+        />
+      </SectionTitleWithLink>
       <ArticlesView
         initPosts={content}
         displayLoadMore={false}
         displayExcerpt={false}
         displayDateAuthor={true}
-        hideCategory={true}
-        textColor={STANFORD_COLORS.WHITE}
+        noDates={true}
+        isSatire2={true}
       />
     </Section>
   );

--- a/components/pages/HomePage/SectionTitle.tsx
+++ b/components/pages/HomePage/SectionTitle.tsx
@@ -35,6 +35,7 @@ type SectionTitleProps = {
   category?: Category;
   children?: ReactNode;
   style?: any;
+  isSatire?: Boolean;
 };
 
 // Used in MoreFromTheDailySection on homepage,
@@ -65,9 +66,14 @@ type SectionTitleWithLinkProps = SectionTitleProps & {
 // except in the MoreFromTheDaily section
 export const SectionTitleWithLink: React.ElementType<
   SectionTitleWithLinkProps
-> = ({ category, style, children }: SectionTitleWithLinkProps) => {
+> = ({
+  category,
+  style,
+  children,
+  isSatire = false,
+}: SectionTitleWithLinkProps) => {
   return (
-    <CategoryLink category={category}>
+    <CategoryLink category={category} isSatire={isSatire}>
       <SectionTitle category={category} style={style}>
         {Platform.OS === "web"
           ? children

--- a/components/pages/HomePage/TextOnlyArticle.tsx
+++ b/components/pages/HomePage/TextOnlyArticle.tsx
@@ -19,6 +19,9 @@ export const TextOnlyArticle: React.ElementType = ({
   displayExcerpt = true,
   displayDateAuthor = true,
   textColor = STANFORD_COLORS.BLACK,
+  noDate = false,
+  isSatire = false,
+  isSatire2 = false,
 }: ArticleProps) => {
   const { tsdPrimaryCategory } = post;
   return (
@@ -36,8 +39,10 @@ export const TextOnlyArticle: React.ElementType = ({
           }}
         >
           <CategoryLink
-            category={tsdPrimaryCategory}
+            category={isSatire ? null : tsdPrimaryCategory}
             style={{ color: textColor }}
+            isSatire={isSatire}
+            isSatire2={isSatire2}
           />
         </View>
       )}
@@ -53,7 +58,11 @@ export const TextOnlyArticle: React.ElementType = ({
         }}
       >
         <ArticleHeader>
-          <ArticleTitleWithLink post={post} style={{ color: textColor }} />
+          <ArticleTitleWithLink
+            post={post}
+            marginBottomMore
+            style={{ color: textColor }}
+          />
         </ArticleHeader>
         {displayExcerpt && (
           <PostExcerpt post={post} style={{ color: textColor }} />
@@ -61,7 +70,8 @@ export const TextOnlyArticle: React.ElementType = ({
         {displayDateAuthor && (
           <AuthorAndDateView
             post={post}
-            style={{ marginTop: 5, color: textColor }}
+            style={{ color: textColor }}
+            noDate={noDate}
           />
         )}
       </View>

--- a/components/pages/HomePage/TitleOnlyArticle.tsx
+++ b/components/pages/HomePage/TitleOnlyArticle.tsx
@@ -10,9 +10,9 @@ export const TitleOnlyArticle: React.ElementType = ({ post }: ArticleProps) => {
   return (
     <Article post={post}>
       <ArticleHeader>
-        <ArticleTitleWithLink post={post} />
+        <ArticleTitleWithLink marginBottomMore post={post} />
       </ArticleHeader>
-      <AuthorAndDateView post={post} newLineBetweenAuthorAndDate />
+      <AuthorAndDateView post={post} noDate />
     </Article>
   );
 };

--- a/components/pages/HomePage/TopThumbnailArticle.tsx
+++ b/components/pages/HomePage/TopThumbnailArticle.tsx
@@ -27,9 +27,9 @@ export const TopThumbnailArticle: React.ElementType = ({
         `}
       />
       <ArticleHeader>
-        <ArticleTitleWithLink post={post} />
+        <ArticleTitleWithLink marginBottomMore post={post} />
       </ArticleHeader>
-      <AuthorAndDateView post={post} newLineBetweenAuthorAndDate />
+      <AuthorAndDateView post={post} noDate />
     </Article>
   );
 };

--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -280,6 +280,9 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
                 ...getBorderValue("Bottom"),
               }}
             /> */}
+            {console.log(homePosts)}
+            {console.log("What?")}
+            {console.log(homePosts.tsdMeta.categories.cartoons)}
             <SatireSection
               category={homePosts.tsdMeta.categories.satire}
               content={homePosts.satire}


### PR DESCRIPTION
Homepage improvements: Remove dates from articles on homepage; add custom logos for Cartoons and Satire; changed color of Satire background and font on homepage and added the Satire category name above those posts on the homepage; Updated COVID-19 tracker data, moved the headline above the tracking boxes and updated caption text to clarify meaning of arrows

## Reasons for making this change

Various

## Related tickets

[If this is related to existing tickets, include links to them as well ("fixes #[issue number]")]

## Screenshots

[If this is a visual change, please add screenshots showing how the website looks like]

[Desktop screenshot]

[Mobile screenshot]
