### PR TITLE
Added 'Alumni' link to top bar, footer, modified homepage section logos...

### DIFF
--- a/components/FooterContent.tsx
+++ b/components/FooterContent.tsx
@@ -349,6 +349,30 @@ export const FooterContent: React.ElementType = ({ style }: any) => {
       url: "/category/cartoons/",
       children: {},
     },
+    aboutUs: {
+      id: null,
+      name: "About us",
+      url: "/about/",
+      children: {},
+    },
+    alumni: {
+      id: null,
+      name: "Alumni",
+      url: "https://alumni.stanforddaily.com/",
+      children: {},
+    },
+    advertise: {
+      id: null,
+      name: "Advertise",
+      url: "/advertise/",
+      children: {},
+    },
+    archives: {
+      id: null,
+      name: "Archives",
+      url: "https://archives.stanforddaily.com/",
+      children: {},
+    },
   };
 
   const BottomText = styled.Text({

--- a/components/TopBarLinks.tsx
+++ b/components/TopBarLinks.tsx
@@ -126,6 +126,11 @@ export const TopBarLinks: React.ElementType = ({ itemStyle }: any) => {
     } as LinkLink,
     {
       type: LinkType.LINK,
+      name: "Alumni",
+      url: "https://alumni.stanforddaily.com/",
+    } as LinkLink,
+    {
+      type: LinkType.LINK,
       name: "Advertising",
       url: "/advertise/",
     } as LinkLink,

--- a/components/pages/HomePage/CartoonsSection.tsx
+++ b/components/pages/HomePage/CartoonsSection.tsx
@@ -29,8 +29,8 @@ export const CartoonsSection: React.ElementType = ({
             accessibilityLabel="Cartoons"
             resizeMode="contain"
             style={{
-              width: 200,
-              height: 65,
+              width: 180,
+              height: 60,
             }}
           />
         </SectionTitleWithLink>

--- a/components/pages/HomePage/GrindSection.tsx
+++ b/components/pages/HomePage/GrindSection.tsx
@@ -23,6 +23,7 @@ export const GrindSection: React.ElementType = ({
           style={{
             height: 30,
             width: 105,
+            marginBottom: -5,
           }}
         />
       }

--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -32,10 +32,11 @@ import { Column } from "./Column";
 import { getBorderValue } from "./getBorderValue";
 import { CovidDataWidget } from "./CovidDataWidget";
 import { SectionProps } from "./SectionProps";
-import { SectionStyle, Section } from "components/Section";
+import { SectionStyle, Section, SECTION_PADDING } from "components/Section";
 import { SectionTitleWithLink } from "./SectionTitle";
 import { TopThumbnailArticle } from "./TopThumbnailArticle";
 import { TitleOnlyArticle } from "./TitleOnlyArticle";
+import { HeadlineArticle } from "./HeadlineArticle";
 
 interface IndexProps {
   homePosts?: Home;
@@ -141,7 +142,7 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
               />
             </SectionTitleWithLink>
           </SectionStyle>
-          <div style={{ marginTop: -25 }}>
+          <div style={{ marginTop: -35 }}>
             <Section>
               <View>
                 <TopThumbnailArticle post={homePosts.artsAndLife[0]} />
@@ -161,20 +162,73 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
       );
     };
     const MainSportsSection: React.ElementType = (msProps: SectionProps) => {
+      const content = homePosts.sports;
       return (
-        <MainSection
-          content={homePosts.sports}
-          category={homePosts.tsdMeta.categories.sports}
-          sectionTitle="Sports"
-          rStyle={{
-            [MediaRule.MaxWidth]: {
-              [BREAKPOINTS.MAX_WIDTH.TABLET]: {
-                ...getBorderValue("Bottom"),
+        <Column
+          style={{
+            flexGrow: 7,
+            order: 1,
+          }}
+          rStyle={mergeRStyle(
+            {
+              [MediaRule.MinWidth]: {
+                [BREAKPOINTS.TABLET]: {
+                  order: 2,
+                },
               },
             },
-          }}
-          {...msProps}
-        />
+            {
+              [MediaRule.MaxWidth]: {
+                [BREAKPOINTS.MAX_WIDTH.TABLET]: {
+                  ...getBorderValue("Bottom"),
+                },
+              },
+            },
+          )}
+        >
+          <Section>
+            <SectionTitleWithLink
+              category={homePosts.tsdMeta.categories.sports}
+            >
+              <Image
+                source={{
+                  uri: "/static/sectionHeaders/sports.png",
+                }}
+                accessibilityLabel="Sports"
+                resizeMode="contain"
+                style={{
+                  width: 100,
+                  height: 25,
+                }}
+              />
+            </SectionTitleWithLink>
+            <HeadlineArticle post={content[0]} style={{ marginBottom: 20 }} />
+            <DesktopRow>
+              <Column
+                rStyle={{
+                  [MediaRule.MinWidth]: {
+                    [BREAKPOINTS.TABLET]: {
+                      paddingRight: SECTION_PADDING / 2,
+                    },
+                  },
+                }}
+              >
+                <TopThumbnailArticle post={content[1]} />
+              </Column>
+              <Column
+                rStyle={{
+                  [MediaRule.MinWidth]: {
+                    [BREAKPOINTS.TABLET]: {
+                      paddingLeft: SECTION_PADDING / 2,
+                    },
+                  },
+                }}
+              >
+                <TopThumbnailArticle post={content[2]} />
+              </Column>
+            </DesktopRow>
+          </Section>
+        </Column>
       );
     };
 
@@ -280,9 +334,6 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
                 ...getBorderValue("Bottom"),
               }}
             /> */}
-            {console.log(homePosts)}
-            {console.log("What?")}
-            {console.log(homePosts.tsdMeta.categories.cartoons)}
             <SatireSection
               category={homePosts.tsdMeta.categories.satire}
               content={homePosts.satire}


### PR DESCRIPTION
Added 'Alumni' link to top bar and added non-section links on top bar to footer as well; restored Sports custom logo on homepage and made some spacing changes on A&L, Grind, Cartoons logos

## Reasons for making this change

Finished new version of alumni.stanforddaily.com and want to advertise it more!
Also continuing work on homepage

## Related tickets

[If this is related to existing tickets, include links to them as well ("fixes #[issue number]")]

## Screenshots

[If this is a visual change, please add screenshots showing how the website looks like]

[Desktop screenshot]

[Mobile screenshot]
