### PR TITLE
Added @media print CSS rules to clean up post format when printing/saving as PDF

### DIFF
--- a/components/AuthorBox.tsx
+++ b/components/AuthorBox.tsx
@@ -3,6 +3,7 @@ import { View, Text } from "react-native";
 import { Author } from "helpers/wpapi";
 import { FONTS, COLORS, STANFORD_COLORS } from "helpers/constants";
 import { AuthorView } from "./pages/HomePage/AuthorView";
+import css from "@emotion/css";
 
 // Describes requirement of having author property that is
 // an Author and linkToAuthor property that is a boolean
@@ -29,6 +30,11 @@ const AuthorBox: React.ElementType<AuthorBoxProps> = ({
         backgroundColor: STANFORD_COLORS.LIGHT_SANDSTONE,
         marginBottom: 10,
       }}
+      css={css`
+        @media print {
+          display: none;
+        }
+      `}
     >
       <View>
         <img

--- a/components/CategoryLink.tsx
+++ b/components/CategoryLink.tsx
@@ -4,6 +4,7 @@ import { FONTS } from "helpers/constants";
 import { Category, getNextJsCategoryPath } from "helpers/wpapi";
 import { withNavigation } from "helpers/trivial/react-navigation";
 import Link from "./Link";
+import css from "@emotion/css";
 
 // Describes requirement of various properties of specific types
 // https://www.typescriptlang.org/docs/handbook/interfaces.html
@@ -54,6 +55,11 @@ const _CategoryLink: React.ElementType<CategoryLinkProps> = ({
         ...FONTS.AUXILIARY,
         ...style,
       }}
+      css={css`
+        @media print {
+          display: none;
+        }
+      `}
     >
       {category || isSatire || isSatire2 ? (
         <Link

--- a/components/ContentView.tsx
+++ b/components/ContentView.tsx
@@ -16,6 +16,7 @@ import { DateWithAbbr } from "./DateView";
 import SatireGlobal from "./SatireGlobal";
 import DataVizGlobal from "./DataVizGlobal";
 import FooterDonationBanner from "components/FooterDonationBanner";
+import css from "@emotion/css";
 
 import ContentViewStyles, {
   centerOuterContentStyle,
@@ -132,9 +133,28 @@ const ContentView: React.ElementType<ContentViewProps> = ({
           )}
         </ArticleHeader>
         <Global styles={ContentViewStyles} />
-        <RView WebTag="main" id="main-article-content">
+        <RView
+          WebTag="main"
+          id="main-article-content"
+          css={css`
+            @media print {
+              a {
+                text-decoration: none !important;
+                border-bottom: none !important;
+                color: #2e2d29;
+              }
+            }
+          `}
+        >
           {thumbnailUrl ? (
-            <figure id="featured-image">
+            <figure
+              id="featured-image"
+              css={css`
+                @media print {
+                  display: none;
+                }
+              `}
+            >
               <img src={thumbnailUrl} alt={thumbnailAlt} />
               {thumbnailCaption ? (
                 <figcaption style={{ marginBottom: 0 }}>
@@ -183,7 +203,13 @@ const ContentView: React.ElementType<ContentViewProps> = ({
         )}
       </Article>
       {commentStatus === "open" && (
-        <React.Fragment>
+        <div
+          css={css`
+            @media print {
+              display: none;
+            }
+          `}
+        >
           <div css={{ ...centerContentStyle }}>
             {/* We have to embed disqus this way (and not through disqus-react) because disqus-react requires
             Next JS's javascript code to be running -- and we had to turn off the Next JS javascript code
@@ -219,7 +245,7 @@ const ContentView: React.ElementType<ContentViewProps> = ({
               }}
             />
           </div>
-        </React.Fragment>
+        </div>
       )}
       <WPFooter base={post} />
     </SectionStyle>

--- a/components/DonationForm.tsx
+++ b/components/DonationForm.tsx
@@ -101,7 +101,7 @@ const DonationForm: React.ElementType = ({
                 setIsRecurring(!isRecurring);
               }}
             />
-            Make a monthly donation.
+            Make a monthly donation. Awesome!
           </label>
         </div>
 
@@ -149,7 +149,13 @@ const DonationForm: React.ElementType = ({
         <input type="hidden" name="item_name" value="Stanford Daily Donation" />
         <input type="hidden" name="item_number" value={notes} />
         <input type="hidden" name="currency_code" value="USD" />
-        <div>
+        <div
+          css={css`
+            @media print {
+              display: none;
+            }
+          `}
+        >
           <div
             style={{
               backgroundColor: "#54100b",
@@ -238,7 +244,7 @@ const DonationForm: React.ElementType = ({
                   setIsRecurring(!isRecurring);
                 }}
               />
-              Make a monthly donation.
+              Make a monthly donation. Awesome!
             </label>
             <button
               type="submit"

--- a/components/FooterContent.tsx
+++ b/components/FooterContent.tsx
@@ -413,6 +413,9 @@ export const FooterContent: React.ElementType = ({ style }: any) => {
         a {
           line-height: 1.5em;
         }
+        @media print {
+          display: none;
+        }
       `}
       rStyle={{
         [MediaRule.MinWidth]: {

--- a/components/FooterDonationBanner.tsx
+++ b/components/FooterDonationBanner.tsx
@@ -7,6 +7,7 @@ import LogoInstagram from "react-ionicons/lib/LogoInstagram";
 import LogoYoutube from "react-ionicons/lib/LogoYoutube";
 import { LINKS, FONTS, STANFORD_COLORS } from "helpers/constants";
 import Link from "components/Link";
+import css from "@emotion/css";
 
 const LogoIconWithLink: React.ElementType = ({ url, LogoComponent }: any) => (
   <a
@@ -68,6 +69,11 @@ const FooterDonationBanner: React.ElementType = ({ currentPageUrl }) => {
         marginTop: SECTION_PADDING,
         marginBottom: SECTION_PADDING,
       }}
+      css={css`
+        @media print {
+          display: none;
+        }
+      `}
     >
       <h3
         style={{

--- a/components/SearchLink.tsx
+++ b/components/SearchLink.tsx
@@ -1,6 +1,7 @@
 import RView from "emotion-native-media-query";
 import { FONTS } from "helpers/constants";
 import React from "react";
+import css from "@emotion/css";
 
 import styled from "@emotion/styled";
 import IosSearch from "react-ionicons/lib/IosSearch";
@@ -33,6 +34,11 @@ export default () => (
     style={{
       marginRight: 20,
     }}
+    css={css`
+      @media print {
+        display: none;
+      }
+    `}
   >
     <form
       role="search"

--- a/components/TopBarLinks.tsx
+++ b/components/TopBarLinks.tsx
@@ -5,6 +5,7 @@ import { Category } from "helpers/wpapi";
 import { SECTION_PADDING } from "./Section";
 import { CategoryLink } from "./CategoryLink";
 import SearchLink from "./SearchLink";
+import css from "@emotion/css";
 
 enum LinkType {
   LINK,
@@ -166,7 +167,6 @@ export const TopBarLinks: React.ElementType = ({ itemStyle }: any) => {
           marginRight: 25,
           paddingTop: SECTION_PADDING,
           paddingBottom: SECTION_PADDING,
-          ..._itemStyle,
         };
         if (item.type === LinkType.SEARCH) {
           return <SearchLink />;
@@ -186,7 +186,15 @@ export const TopBarLinks: React.ElementType = ({ itemStyle }: any) => {
             return <></>;
           }
           return (
-            <Text style={actualStyle} key={link.url}>
+            <Text
+              style={actualStyle}
+              key={link.url}
+              css={css`
+                @media print {
+                  display: none;
+                }
+              `}
+            >
               <a href={link.url} style={{ color: "inherit" }}>
                 {link.name}
               </a>

--- a/components/pages/HomePage/TopSection.tsx
+++ b/components/pages/HomePage/TopSection.tsx
@@ -203,7 +203,14 @@ const ViewRow: any = styled(View)({
 // and nav bar on every page of the website
 export const TopSection: React.ElementType = ({ style }) => {
   return (
-    <SectionStyle style={{ paddingTop: 10, paddingBottom: 10 }}>
+    <SectionStyle
+      style={{ paddingTop: 10, paddingBottom: 10 }}
+      css={css`
+        @media print {
+          display: none;
+        }
+      `}
+    >
       <View
         css={css`
           flex-direction: row;
@@ -272,7 +279,7 @@ export const TopSection: React.ElementType = ({ style }) => {
               header="Podcasts"
               title="The Daily Brew & More"
             /> */}
-          { /* <SmallSection
+          {/* <SmallSection
             className="small-section small-section-adopt-a-small-business"
             url="/adopt-a-small-business-with-stanford-daily-advertising"
             imageUrl={LINKS.ADOPT_A_BUSINESS_LOGO}


### PR DESCRIPTION
## Reasons for making this change

Requested by editorial — format was previously horrendous

## Screenshots

**[Before]**
<img width="469" alt="Screen Shot 2020-10-24 at 1 25 52 PM" src="https://user-images.githubusercontent.com/38192823/97092897-80190f80-15fc-11eb-8f30-e2dd6eedb44d.png">
<img width="469" alt="Screen Shot 2020-10-24 at 1 25 59 PM" src="https://user-images.githubusercontent.com/38192823/97092899-80b1a600-15fc-11eb-9024-199308afbcab.png">

**[After]**
<img width="458" alt="Screen Shot 2020-10-24 at 1 24 41 PM" src="https://user-images.githubusercontent.com/38192823/97092871-4f38da80-15fc-11eb-91a8-427537b7ed7e.png">