### PR TITLE
Changed Podcasts section links so that they direct to Spotify...

### DIFF
--- a/components/FooterContent.tsx
+++ b/components/FooterContent.tsx
@@ -332,7 +332,7 @@ export const FooterContent: React.ElementType = ({ style }: any) => {
       id: null,
       name: "Podcasts",
       slug: "podcasts",
-      url: "/category/podcasts/",
+      url: LINKS.THE_DAILY_BREW_SPOTIFY,
       children: {},
     },
     video: {

--- a/components/TopBarLinks.tsx
+++ b/components/TopBarLinks.tsx
@@ -103,7 +103,7 @@ export const TopBarLinks: React.ElementType = ({ itemStyle }: any) => {
     {
       type: LinkType.LINK,
       name: "Podcasts",
-      url: "/category/podcasts/",
+      url: LINKS.THE_DAILY_BREW_SPOTIFY,
     } as LinkLink,
     {
       type: LinkType.LINK,

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -110,6 +110,8 @@ export const LINKS = {
   INSTAGRAM: "https://www.instagram.com/stanforddaily/",
   YOUTUBE: "https://www.youtube.com/channel/UCWg3QqUzqxXt6herm5sMjNw",
   ISSUU: "https://issuu.com/thestanforddaily",
+  THE_DAILY_BREW_SPOTIFY:
+    "https://open.spotify.com/show/2ty8gvAnvYP31X8TUrFwoj?si=cZWDWKp2SiOotNh4ZqG0xg",
   NEWSLETTER_LOGO:
     "https://wp.stanforddaily.com/wp-content/uploads/2020/02/weekend_roundup_logo-1.jpg",
   DAILY_BREW_LOGO:


### PR DESCRIPTION
… instead of our relatively unused Podcasts category page

## Reasons for making this change

Above: "relatively unused Podcasts category page"

## Related tickets

[If this is related to existing tickets, include links to them as well ("fixes #[issue number]")]

## Screenshots

[If this is a visual change, please add screenshots showing how the website looks like]

[Desktop screenshot]

[Mobile screenshot]
