### PR TITLE
Changed font and modified font sizes of top bar links and author views…

### DIFF
--- a/components/SearchLink.tsx
+++ b/components/SearchLink.tsx
@@ -21,7 +21,7 @@ const SearchInput = styled(
   styled.input({
     ...inputStyle,
     ...FONTS.AUXILIARY,
-    width: 60,
+    width: 65,
   }),
 )`
   ::placeholder {
@@ -56,6 +56,7 @@ export default () => (
         name="s"
         id="s"
         required
+        style={{ fontSize: 12.5 }}
       />
       <button
         type="submit"

--- a/components/TopBarLinks.tsx
+++ b/components/TopBarLinks.tsx
@@ -167,6 +167,7 @@ export const TopBarLinks: React.ElementType = ({ itemStyle }: any) => {
           marginRight: 25,
           paddingTop: SECTION_PADDING,
           paddingBottom: SECTION_PADDING,
+          fontSize: 12.5,
         };
         if (item.type === LinkType.SEARCH) {
           return <SearchLink />;

--- a/components/pages/HomePage/AuthorView.tsx
+++ b/components/pages/HomePage/AuthorView.tsx
@@ -16,7 +16,12 @@ export const AuthorsTextWithLink: React.ElementType = ({
 }) => {
   const authorsTextWithLink = authors.map((author, index) => (
     <React.Fragment key={author.id}>
-      {index > 0 && (authors.length !== 2 ? ", " : " ")}
+      {index > 0 &&
+        (index === authors.length - 1
+          ? " "
+          : authors.length !== 2
+          ? ", "
+          : " ")}
       {index > 0 && index === authors.length - 1 && (
         <span style={{ textTransform: "none" }}>and </span>
       )}
@@ -61,6 +66,7 @@ export const AuthorView: React.ElementType = ({
       <View style={containerStyle}>
         <Text
           style={{
+            fontSize: 12.5,
             ...FONTS.AUXILIARY,
             ...style,
           }}

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -58,7 +58,7 @@ export const FONTS: any = {
   AUXILIARY:
     Platform.OS === "web"
       ? {
-          fontFamily: "'IBM Plex Sans Condensed', sans-serif",
+          fontFamily: "Segoe UI, Roboto,Ubuntu, Helvetica Neue, sans-serif",
           textTransform: "uppercase",
           lineHeight: "1em",
         }


### PR DESCRIPTION
…also fixed copy error of Oxford comma appearing in lists of 3 or more author names

## Reasons for making this change

Because Charlie didn't like the previous font and because Oxford commas in lists of names are against Daily style

## Screenshots

**BEFORE**
<img width="1440" alt="Screen Shot 2020-10-26 at 8 01 48 PM" src="https://user-images.githubusercontent.com/38192823/97251959-22d0ba00-17c6-11eb-9b88-294d318c0ee3.png">

**AFTER**
<img width="1440" alt="Screen Shot 2020-10-26 at 8 02 37 PM" src="https://user-images.githubusercontent.com/38192823/97251996-39771100-17c6-11eb-9f2b-37d3fd6c30e2.png">
