### PR TITLE
Added basic table and td styles

### DIFF
--- a/components/ContentViewStyles.tsx
+++ b/components/ContentViewStyles.tsx
@@ -68,5 +68,16 @@ export default {
         width: "100% !important",
       },
     },
+    table: {
+      width: "100%",
+      borderCollapse: "collapse",
+      textAlign: "center",
+      border: `1px solid ${STANFORD_COLORS.COOL_GREY}`,
+      fontSize: "1.3rem",
+    },
+    td: {
+      border: `1px solid ${STANFORD_COLORS.COOL_GREY}`,
+      padding: "10px",
+    },
   },
 };


### PR DESCRIPTION
## Reasons for making this change

Want to get more use out of the built-in table block in WordPress

## Screenshots

**BEFORE**
<img width="1440" alt="Screen Shot 2020-10-27 at 9 36 49 AM" src="https://user-images.githubusercontent.com/38192823/97332685-f8b7e000-1837-11eb-9efa-d7f74539ea39.png">

**AFTER**
<img width="1440" alt="Screen Shot 2020-10-27 at 9 37 24 AM" src="https://user-images.githubusercontent.com/38192823/97332738-0a00ec80-1838-11eb-8111-571d822c03fc.png">
