### PR TITLE
Set Cartoons homepage img to 100% width with no height specification …

### DIFF
--- a/components/pages/HomePage/CartoonsSection.tsx
+++ b/components/pages/HomePage/CartoonsSection.tsx
@@ -35,7 +35,7 @@ export const CartoonsSection: React.ElementType = ({
           />
         </SectionTitleWithLink>
         <LinkToArticle post={content[0]}>
-          <Image
+          {/* <Image
             source={{
               uri: content[0].thumbnailInfo.urls.full,
             }}
@@ -44,6 +44,10 @@ export const CartoonsSection: React.ElementType = ({
               width: "100%",
               height: 400,
             }}
+          /> */}
+          <img
+            src={content[0].thumbnailInfo.urls.full}
+            style={{ width: "100%" }}
           />
         </LinkToArticle>
       </RView>


### PR DESCRIPTION
…to prevent empty space and disproportionate images — may now result in tall homepage when featured cartoon is tall

## Reasons for making this change

Lots of whitespace appearing due to cartoons with height under 400px

## Screenshots

**BEFORE**
<img width="1440" alt="Screen Shot 2020-10-31 at 9 00 15 PM" src="https://user-images.githubusercontent.com/38192823/97794829-1b415480-1bbc-11eb-995c-41b554389ba7.png">

**AFTER**
<img width="1440" alt="Screen Shot 2020-10-31 at 8 58 14 PM" src="https://user-images.githubusercontent.com/38192823/97794820-f77e0e80-1bbb-11eb-8262-d20d36891759.png">
