### PR TITLE
Applied image-rendering CSS property value

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -70,6 +70,7 @@ const HeaderLogo: React.ElementType = () => {
                 src="https://raw.githubusercontent.com/TheStanfordDaily/stanforddaily-graphic-assets/main/DailyLogo/DailyLogo.png"
                 alt="The Stanford Daily"
                 css={{
+                  imageRendering: "-webkit-optimize-contrast",
                   height: "auto",
                   width: "auto",
                   maxHeight: "100%",


### PR DESCRIPTION
 Applied image-rendering CSS property value of '-webkit-optimize-contrast' to Daily logo in an attempt to make it sharper

## Reasons for making this change

Requested by Charlie Curnin

## Screenshots

**BEFORE**
<img width="1440" alt="Screen Shot 2020-11-12 at 7 16 10 PM" src="https://user-images.githubusercontent.com/38192823/99024490-92131180-251b-11eb-8594-f69fe1289f2b.png">

**AFTER**
<img width="1440" alt="Screen Shot 2020-11-12 at 7 15 24 PM" src="https://user-images.githubusercontent.com/38192823/99024456-7ad42400-251b-11eb-981e-d284adbf93a9.png">