### PR TITLE
add metadata to ContentView for parse.ly

### DIFF
--- a/components/ContentView.tsx
+++ b/components/ContentView.tsx
@@ -68,11 +68,14 @@ const ContentView: React.ElementType<ContentViewProps> = ({
     id: postId,
     postTitle,
     postSubtitle,
+    tagsInput,
     thumbnailInfo,
     tsdAuthors,
     tsdCategories, // e.g. News
     tsdPrimaryCategory, // for articles with more than one, selected in WordPress
+    tsdUrlParameters,
     postContent,
+    postDateGmt,
     postType,
     commentStatus, // determines whether Disqus appears below article
     guid,
@@ -239,6 +242,26 @@ const ContentView: React.ElementType<ContentViewProps> = ({
             })();
           </script>
           `,
+              }}
+            />
+            <div
+              dangerouslySetInnerHTML={{
+                __html: `<script type="application/ld+json">${JSON.stringify({
+                  "@context": "http://schema.org",
+                  "@type": "NewsArticle",
+                  headline: postTitle,
+                  url: isPost
+                    ? `www.stanforddaily.com/${tsdUrlParameters.year}/${tsdUrlParameters.month}/${tsdUrlParameters.day}/${tsdUrlParameters.slug}`
+                    : `www.stanforddaily.com/${tsdUrlParameters.slug}`,
+                  thumbnailUrl:
+                    thumbnailInfo &&
+                    thumbnailInfo.urls &&
+                    thumbnailInfo.urls.full,
+                  datePublished: postDateGmt,
+                  articleSection: tsdPrimaryCategory && tsdPrimaryCategory.name,
+                  creator: tsdAuthors.map(author => author.displayName),
+                  keywords: tagsInput,
+                })}</script>`,
               }}
             />
           </div>


### PR DESCRIPTION
## Reasons for making this change
Attempt to fix parse.ly issues per documentation here: https://www.parse.ly/help/integration/jsonld#about-the-json-ld-tag

## Screenshots
<img width="1439" alt="Screen Shot 2021-08-29 at 2 14 34 PM" src="https://user-images.githubusercontent.com/38192823/131265502-8e54e032-ba73-47d1-b393-cb87980ffe69.png">

In action at: http://localhost:3000/2021/08/05/opinion-stanfords-dining-hall-system-did-not-work-with-my-disordered-eating-that-can-change
