### PR TITLE
Add metadata for parse.ly to homepage, category and author pages

### DIFF
--- a/components/ContentView.tsx
+++ b/components/ContentView.tsx
@@ -68,11 +68,14 @@ const ContentView: React.ElementType<ContentViewProps> = ({
     id: postId,
     postTitle,
     postSubtitle,
+    tagsInput,
     thumbnailInfo,
     tsdAuthors,
     tsdCategories, // e.g. News
     tsdPrimaryCategory, // for articles with more than one, selected in WordPress
+    tsdUrlParameters,
     postContent,
+    postDateGmt,
     postType,
     commentStatus, // determines whether Disqus appears below article
     guid,
@@ -239,6 +242,26 @@ const ContentView: React.ElementType<ContentViewProps> = ({
             })();
           </script>
           `,
+              }}
+            />
+            <div
+              dangerouslySetInnerHTML={{
+                __html: `<script type="application/ld+json">${JSON.stringify({
+                  "@context": "http://schema.org",
+                  "@type": "NewsArticle",
+                  headline: postTitle,
+                  url: isPost
+                    ? `www.stanforddaily.com/${tsdUrlParameters.year}/${tsdUrlParameters.month}/${tsdUrlParameters.day}/${tsdUrlParameters.slug}`
+                    : `www.stanforddaily.com/${tsdUrlParameters.slug}`,
+                  thumbnailUrl:
+                    thumbnailInfo &&
+                    thumbnailInfo.urls &&
+                    thumbnailInfo.urls.full,
+                  datePublished: postDateGmt,
+                  articleSection: tsdPrimaryCategory && tsdPrimaryCategory.name,
+                  creator: tsdAuthors.map(author => author.displayName),
+                  keywords: tagsInput,
+                })}</script>`,
               }}
             />
           </div>

--- a/components/ContentView.tsx
+++ b/components/ContentView.tsx
@@ -248,7 +248,7 @@ const ContentView: React.ElementType<ContentViewProps> = ({
               dangerouslySetInnerHTML={{
                 __html: `<script type="application/ld+json">${JSON.stringify({
                   "@context": "http://schema.org",
-                  "@type": "NewsArticle",
+                  "@type": isPost ? "NewsArticle" : "WebPage",
                   headline: postTitle,
                   url: isPost
                     ? `www.stanforddaily.com/${tsdUrlParameters.year}/${tsdUrlParameters.month}/${tsdUrlParameters.day}/${tsdUrlParameters.slug}`
@@ -260,7 +260,13 @@ const ContentView: React.ElementType<ContentViewProps> = ({
                   datePublished: postDateGmt,
                   articleSection: tsdPrimaryCategory && tsdPrimaryCategory.name,
                   creator: tsdAuthors.map(author => author.displayName),
-                  keywords: tagsInput,
+                  keywords: tagsInput.concat(
+                    tsdCategories
+                      .filter(
+                        category => category.name !== tsdPrimaryCategory.name,
+                      )
+                      .map(category => category.name),
+                  ),
                 })}</script>`,
               }}
             />

--- a/components/pages/ArticleListPage/AuthorArticleListPage.tsx
+++ b/components/pages/ArticleListPage/AuthorArticleListPage.tsx
@@ -50,6 +50,15 @@ export default class AuthorArticleListPage extends React.Component<
           }}
           {...this.props}
         />
+        <div
+          dangerouslySetInnerHTML={{
+            __html: `<script type="application/ld+json">${JSON.stringify({
+              "@context": "http://schema.org",
+              "@type": "WebPage",
+              url: `www.stanforddaily.com/author/${slug}`,
+            })}</script>`,
+          }}
+        />
       </Section>
     );
   }

--- a/components/pages/ArticleListPage/CategoryArticleListPage.tsx
+++ b/components/pages/ArticleListPage/CategoryArticleListPage.tsx
@@ -64,10 +64,25 @@ export default class CategoryArticleListPage extends React.Component<
       />
     );
 
+    const metaData = (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: `<script type="application/ld+json">${JSON.stringify({
+            "@context": "http://schema.org",
+            "@type": "WebPage",
+            url: `www.stanforddaily.com/category/${slugs[slugs.length - 1]}`,
+          })}</script>`,
+        }}
+      />
+    );
+
     if (Platform.OS !== "web") {
       // We do not need header on mobile
       return (
-        <SafeAreaView style={{ flex: 1 }}>{_articleListPage}</SafeAreaView>
+        <SafeAreaView style={{ flex: 1 }}>
+          {_articleListPage}
+          {metaData}
+        </SafeAreaView>
       );
     }
 
@@ -92,6 +107,7 @@ export default class CategoryArticleListPage extends React.Component<
         )}
         {initData.tsdMeta.title === "Humor" && <HumorGlobal />}
         {_articleListPage}
+        {metaData}
       </Section>
     );
   }

--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -349,6 +349,15 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
             />
           </ScrollView>
           <WPFooter base={homePosts} />
+          <div
+            dangerouslySetInnerHTML={{
+              __html: `<script type="application/ld+json">${JSON.stringify({
+                "@context": "http://schema.org",
+                "@type": "WebPage",
+                url: "www.stanforddaily.com",
+              })}</script>`,
+            }}
+          />
         </SafeAreaView>
       </>
     );


### PR DESCRIPTION
## Reasons for making this change
- Follow-up to previous PR since that only set up metadata for posts and pages, whereas this adds it for the homepage, category and author pages as well
- Also updated metadata to differentiate between pages and posts and add non-primary sections as tags

## Screenshots
<img width="1440" alt="Screen Shot 2021-08-30 at 3 49 49 PM" src="https://user-images.githubusercontent.com/38192823/131417868-23bf1c05-5b1b-4c5c-845d-84e8736461c1.png">
