### PR TITLE
fixed url structure

### DIFF
--- a/components/ContentView.tsx
+++ b/components/ContentView.tsx
@@ -251,8 +251,8 @@ const ContentView: React.ElementType<ContentViewProps> = ({
                   "@type": isPost ? "NewsArticle" : "WebPage",
                   headline: postTitle,
                   url: isPost
-                    ? `www.stanforddaily.com/${tsdUrlParameters.year}/${tsdUrlParameters.month}/${tsdUrlParameters.day}/${tsdUrlParameters.slug}`
-                    : `www.stanforddaily.com/${tsdUrlParameters.slug}`,
+                    ? `https://stanforddaily.com/${tsdUrlParameters.year}/${tsdUrlParameters.month}/${tsdUrlParameters.day}/${tsdUrlParameters.slug}`
+                    : `https://stanforddaily.com/${tsdUrlParameters.slug}`,
                   thumbnailUrl:
                     thumbnailInfo &&
                     thumbnailInfo.urls &&

--- a/components/pages/ArticleListPage/AuthorArticleListPage.tsx
+++ b/components/pages/ArticleListPage/AuthorArticleListPage.tsx
@@ -55,7 +55,7 @@ export default class AuthorArticleListPage extends React.Component<
             __html: `<script type="application/ld+json">${JSON.stringify({
               "@context": "http://schema.org",
               "@type": "WebPage",
-              url: `www.stanforddaily.com/author/${slug}`,
+              url: `https://stanforddaily.com/author/${slug}`,
             })}</script>`,
           }}
         />

--- a/components/pages/ArticleListPage/CategoryArticleListPage.tsx
+++ b/components/pages/ArticleListPage/CategoryArticleListPage.tsx
@@ -70,7 +70,9 @@ export default class CategoryArticleListPage extends React.Component<
           __html: `<script type="application/ld+json">${JSON.stringify({
             "@context": "http://schema.org",
             "@type": "WebPage",
-            url: `www.stanforddaily.com/category/${slugs[slugs.length - 1]}`,
+            url: `https://stanforddaily.com/category/${
+              slugs[slugs.length - 1]
+            }`,
           })}</script>`,
         }}
       />

--- a/components/pages/HomePage/index.tsx
+++ b/components/pages/HomePage/index.tsx
@@ -354,7 +354,7 @@ export default class HomePage extends React.Component<IndexProps, IndexState> {
               __html: `<script type="application/ld+json">${JSON.stringify({
                 "@context": "http://schema.org",
                 "@type": "WebPage",
-                url: "www.stanforddaily.com",
+                url: "https://stanforddaily.com",
               })}</script>`,
             }}
           />


### PR DESCRIPTION
## Reasons for making this change

Fixed URL structure to be https:// rather than www. which is in alignment with Parsely's required structure
https://www.parse.ly/help/integration/jsonld#example